### PR TITLE
Added gulpfile.js to generate report for untranslated text component wise

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,23 @@ import * as EJ2_LOCALE from "../../node_modules/@syncfusion/ej2-locale/src/de.js
 L10n.load({ de: EJ2_LOCALE.de });
 setCulture("de");
 ```
+
+### How to generate report of untranslated word and translate text can be translated.
+
+#### To generate report :
+
+Run the gulp task **Localization-Untranslated-Report** to create a report of all the cultures' untranslated text. It will give a report of each file's individual untranslated text that is there, broken down by component wise.
+
+```
+  gulp Localization-Untranslated-Report
+
+```
+
+#### To translate untranslated text
+
+Run the gulp task :**Localization-Translator** to generate a new culture files with the translated text of which can be translated to other culture.
+
+```
+  gulp Localization-Translator
+
+```

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,82 @@
+const fs = require('fs')
+const https = require('https')
+const gulp = require('gulp')
+/**
+ * Gulp task to generate report of text not translated component wise
+ */
+gulp.task('Localization-Translator', async function (done) {
+  let HtmlReport =
+    `<style>
+  table {border-collapse: collapse;}
+  th {border: 5px solid black;color: red;padding: 8px;}
+  td {border: 1px solid black;padding: 8px;}
+</style>
+<table>
+  <thead><tr><th>S.no</th><th>culture</th><th>Component</th><th>Key</th>
+  <th>English Value</th>
+  <th>Existing Value</th><th>Translated Value</th></tr>
+  <tbody>`;
+  let htmlEntry = ``;
+  let serialNo = 1;
+  const list = ['ar-AE', 'ar', 'cs', 'da', 'de', 'es', 'fa', 'fi', 'fr', 'he', 'hr', 'hu', 'id', 'is', 'it', 'ja', 'ko', 'ms', 'nb', 'nl', 'pl', 'pt-BR', 'pt', 'ro', 'ru', 'sk', 'sv', 'th', 'tr', 'vi', 'zh']
+  const English = require(process.cwd() + '/src/en-US.json');
+  var componetslist = English['en-US'];
+  const array = Object.keys(componetslist);
+  for (let i = 0; i < array.length; i++) {
+    for (let j = 0; j < list.length; j++) {
+      const OtherLang = require(__dirname + '/src/' + list[j] + '.json');
+      var jsonValues1 = English["en-US"][array[i]];
+      var jsonValues2 = OtherLang[list[j]][array[i]];
+      const keys1 = Object.keys(jsonValues1);
+      for (const key of keys1) {
+        if (jsonValues1[key] === jsonValues2[key]) {
+          var textToTranslate = jsonValues2[key];
+          var targetLanguage = list[j];
+          let translatedText = await translateText(textToTranslate, targetLanguage);
+          if (translatedText == textToTranslate) {
+            htmlEntry += `<tr><td>${serialNo}</td><td>${list[j]}</td><td>${array[i]}</td><td>${key}</td><td>${textToTranslate}</td><td>${textToTranslate}</td><td>${translatedText}</td></tr></tbody></thead>`;
+            HtmlReport += htmlEntry;
+            htmlEntry = ``;
+            serialNo++;
+          }
+        }
+      }
+    }
+  }
+  HtmlReport += `</tbody></thead></table>`;
+  try {
+    fs.writeFileSync('Report.html', HtmlReport, 'utf-8')
+    console.log('Report Generated sucessfully created successfully!');
+  }
+  catch (e) {
+    console.log('error')
+  }
+  done();
+})
+/**
+ * Google translate API to return translated text.
+ */
+async function translateText(text, targetLanguage) {
+  const sourceLanguage = 'auto';
+  const url = `https://translate.google.com/translate_a/single?client=gtx&sl=${sourceLanguage}&tl=${targetLanguage}&dt=t&q=${encodeURIComponent(text)}`;
+  return new Promise((resolve, reject) => {
+    const req = https.get(url, (response) => {
+      let data = '';
+      response.on('data', (chunk) => {
+        data += chunk;
+      });
+      response.on('end', () => {
+        try {
+          const parsedData = JSON.parse(data);
+          const translatedText = parsedData[0][0][0];
+          resolve(translatedText);
+        } catch (error) {
+          reject(error);
+        }
+      });
+    });
+    req.on('error', (error) => {
+      reject(error);
+    });
+  });
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,7 +4,7 @@ const gulp = require('gulp')
 /**
  * Gulp task to generate report of text not translated component wise
  */
-gulp.task('Localization-Translator', async function (done) {
+gulp.task('Localization-Untranslated-Report', async function (done) {
   let HtmlReport =
     `<style>
   table {border-collapse: collapse;}
@@ -50,6 +50,43 @@ gulp.task('Localization-Translator', async function (done) {
   }
   catch (e) {
     console.log('error')
+  }
+  done();
+})
+/**
+ * Task to translate text which can be translated
+ */
+gulp.task('Localization-Translator', async function (done) {
+  const list = ['ar-AE', 'ar', 'cs', 'da', 'de', 'es', 'fa', 'fi', 'fr', 'he', 'hr', 'hu', 'id', 'is', 'it', 'ja', 'ko', 'ms', 'nb', 'nl', 'pl', 'pt-BR', 'pt', 'ro', 'ru', 'sk', 'sv', 'th', 'tr', 'vi', 'zh']
+  const English = require(process.cwd() + '/src/en-US.json');
+  var componetslist= English['en-US'];
+  const array=Object.keys(componetslist);
+  for (let i = 0; i < list.length; i++) {
+    const OtherLang = require(process.cwd()+ '/src/' + list[i] + '.json');
+    for (let j = 0; j < array.length; j++) {
+      var jsonValues1 = English['en-US'][array[j]];
+      var jsonValues2 = OtherLang[list[i]][array[j]];
+      const keys1 = Object.keys(jsonValues1);
+      for (const key of keys1) {
+        if (jsonValues1[key] === jsonValues2[key]) {
+          var textToTranslate = jsonValues2[key];
+          var targetLanguage = list[i];
+          let translatedText = await translateText(textToTranslate, targetLanguage);
+          if (translatedText != textToTranslate) {
+            jsonValues2[key] = translatedText;
+          }
+        }
+      }
+    }
+    const filePath =process.cwd()+ '/src/' + list[i] + '.json';
+    const jsonString = JSON.stringify(OtherLang, null, 2);
+    fs.writeFile(filePath, jsonString, (err) => {
+      if (err) {
+        console.error(list[i] + ":" + ' Error writing to JSON file:', err);
+        return;
+      }
+      console.log(list[i] + ":" + ' JSON object translated written to file successfully!');
+    });
   }
   done();
 })

--- a/src/ar.json
+++ b/src/ar.json
@@ -1,5 +1,5 @@
 {
-    "ar-AE": {
+    "ar": {
         "grid": {
             "EmptyRecord": "لا سجلات لعرضها",
             "True": "صحيح",

--- a/src/en-US.json
+++ b/src/en-US.json
@@ -1,5 +1,5 @@
 {
-    "en-GB": {
+    "en-US": {
         "grid": {
             "EmptyRecord": "No records to display",
             "True": "true",


### PR DESCRIPTION
### Feature Description
Need to add validation to make sure that all of the text provided on the component side is translated with the culture where the majority of content is translated. If the not translated generated report of not translated and translated the untranslated text .
### Solution Description
Gulp task automation that reads the locale section of each component's culture wise . Then, after retrieving the response from the online translator and checking for untranslated text, it takes the key value pair of the locale's text and translates it with the with the appropriate culture and generate report and automatically translates and write to the file.

### Areas Affected and Ensured
I have ensured that my task won’t affect any of the other feature..

### Additional Checklist
This may vary for different teams or products. Check with your scrum masters.
•	Did you run the automation against your fix? - No
•	Is there any API name change? - No
•	Is there any existing behavior change of other features due to this code change? - No
•	Does your new code introduce new warnings or binding errors? - No
•	Does your code pass all FxCop and StyleCop rules? - NA
•	Did you record this case in the unit test or UI test? - NA

